### PR TITLE
[CB-4077] Separate the actions of removing a plugin from a platform and ...

### DIFF
--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -17,7 +17,7 @@ module.exports = function(platform, project_dir, id, plugins_dir, options, callb
             if (callback) return callback(err);
             else throw err;
         }
-        module.exports.uninstallPlugin(id, plugins_dir, options, callback);
+        module.exports.uninstallPlugin(id, plugins_dir, callback);
     });
 }
 


### PR DESCRIPTION
...removing the plugin entirely

This patch should be coordinated with the matching pull request for cordova-cli.

This patch keeps the original uninstall() interface, and adds two new methods: uninstall.uninstallPlatform(), which removes a plugin from a single platform, and uninstallPlugin(), which removes the plugin from the project's `plugins/` directory.
