### PR TITLE
Bumping elementtree version to support namespaced xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "nopt": "1.0.x",
     "glob": "3.2.x",
-    "elementtree": "0.1.x",
+    "elementtree": "0.1.5",
     "xcode": "0.6.1",
     "plist": "0.4.x",
     "bplist-parser": "0.0.x",


### PR DESCRIPTION
Need this to support BlackBerry plugins adding rim namespaced elements like `<rim:permissions>`and `<rim:permits>`
