### PR TITLE
[CB-4372] Fixed "Plugman fails when fetching local plugins with space in path"

### DIFF
--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -7,6 +7,7 @@ var fetch   = require('../src/fetch'),
     metadata = require('../src/util/metadata'),
     temp    = path.join(os.tmpdir(), 'plugman'),
     test_plugin = path.join(__dirname, 'plugins', 'ChildBrowser'),
+    test_plugin_with_space = path.join(__dirname, 'folder with space', 'plugins', 'ChildBrowser'),
     plugins = require('../src/util/plugins');
 
 describe('fetch', function() {
@@ -25,6 +26,10 @@ describe('fetch', function() {
         it('should copy locally-available plugin to plugins directory', function() {
             fetch(test_plugin, temp);
             expect(cp).toHaveBeenCalledWith('-R', path.join(test_plugin, '*'), path.join(temp, 'id'));
+        });
+        it('should copy locally-available plugin to plugins directory when spaces in path', function() {
+            fetch(test_plugin_with_space, temp);
+            expect(cp).toHaveBeenCalledWith('-R', path.join(test_plugin_with_space, '*'), path.join(temp, 'id'));
         });
         it('should create a symlink if used with `link` param', function() {
             fetch(test_plugin, temp, { link: true });

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -46,7 +46,9 @@ module.exports = function fetchPlugin(plugin_dir, plugins_dir, options, callback
 
         // Copy from the local filesystem.
         // First, read the plugin.xml and grab the ID.
-        plugin_dir = path.join(uri.href, options.subdir);
+        // NOTE: Can't use uri.href here as it will convert spaces to %20 and make path invalid.
+        // Use original plugin_dir value instead.
+        plugin_dir = path.join(plugin_dir, options.subdir);
         var plugin_xml_path = path.join(plugin_dir, 'plugin.xml');
         require('../plugman').emit('log', 'Fetch is reading plugin.xml from location "' + plugin_xml_path + '"...');
         var xml = xml_helpers.parseElementtreeSync(plugin_xml_path);


### PR DESCRIPTION
URI module was converting spaces to %20 which made them invalid.
