### PR TITLE
Fixed "[Error: ENOENT, no such file or directory '\plugman-tmp1375365605...

### DIFF
--- a/src/util/plugins.js
+++ b/src/util/plugins.js
@@ -39,7 +39,7 @@ module.exports = {
         shell.rm('-rf', tmp_dir);
 
         shell.cd(path.dirname(tmp_dir));
-        var cmd = util.format('git clone "%s" "%s"', plugin_git_url, path.basename(tmp_dir));
+        var cmd = util.format('git clone "%s" "%s"', plugin_git_url, tmp_dir);
         require('../../plugman').emit('log', 'Fetching plugin via git-clone command: ' + cmd);
         shell.exec(cmd, {silent: true, async:true}, function(code, output) {
             if (code > 0) {


### PR DESCRIPTION
I couldn't add any plugin, I just got the error:

```
{ [Error: ENOENT, no such file or directory 'C:\Users\<user>\AppData\Local\Temp
\plugman-tmp1375365605837\plugin.xml']
  errno: 34,
  code: 'ENOENT',
  path: 'C:\\Users\\<user>\\AppData\\Local\\Temp\\plugman-tmp1375365605837\\plu
gin.xml',
  syscall: 'open' }
```

For some reason `git clone` doesn't clone into the right directory when given a relative path. So I changed the relative path to the absolute path, and voila, it worked!

(I'm using Windows 7 and "git bash".)
