### PR TITLE
Add lib-file support to Android

### DIFF
--- a/src/platforms/android.js
+++ b/src/platforms/android.js
@@ -43,5 +43,17 @@ module.exports = {
             var dest = path.join(source_el.attrib['target-dir'], path.basename(source_el.attrib['src']));
             common.deleteJava(project_dir, dest);
         }
+    },
+    "lib-file":{
+        install:function(lib_el, plugin_dir, project_dir) {
+            var src = lib_el.attrib.src;
+            var dest = path.join("libs", path.basename(src));
+            common.copyFile(plugin_dir, src, project_dir, dest);
+        },
+        uninstall:function(lib_el, project_dir) {
+            var src = lib_el.attrib.src;
+            var dest = path.join("libs", path.basename(src));
+            common.removeFile(project_dir, dest);
+        }
     }
 };


### PR DESCRIPTION
lib-file does not work in platforms other than Blackberry.
This patch adds lib-file support to Android.

Without this patch the plugman install.js crashes because handler["lib-file"] is undefined.

If you want to test this create a plugin with an <platform name="android"> section and  a lib-file sub-element.
e.g. 
&lt;lib-file src="libs/org.simalliance.openmobileapi.v2.0.2.jar" arch="device"/&gt;

"arch" is ignored because it is not relevant for Android.

With this patch all files listed in lib-file elements are copies to projectdir/lib/ where the Android build tools expect external libraries.
