### PR TITLE
Fix for plist empty string node serialisation

### DIFF
--- a/src/util/config-changes.js
+++ b/src/util/config-changes.js
@@ -379,7 +379,8 @@ module.exports = {
                                         // TODO: could parse the filepath once per unique target instead of on every change
                                         var plistObj = pl.parseFileSync(filepath);
                                         if (plist_helpers.graftPLIST(plistObj, xml_child, selector)) {
-                                            fs.writeFileSync(filepath, plist.build(plistObj));
+                                            var regExp = new RegExp("<string>[ \t\r\n]+?</string>", "g");
+                                            fs.writeFileSync(filepath, plist.build(plistObj).replace(regExp, "<string></string>"));
                                         } else {
                                             throw new Error('grafting to plist "' + filepath + '" during config install went bad :(');
                                         }


### PR DESCRIPTION
when serialising plists using the plist module empty string nodes are serialised with a newline. xcode does not trim string nodes values (as it shouldn't) so it borks.
