### PR TITLE
Correctly tell plugman which object in config to remove

### DIFF
--- a/src/uninstall.js
+++ b/src/uninstall.js
@@ -105,7 +105,7 @@ function runUninstall(actions, platform, project_dir, plugin_dir, plugins_dir, o
                 var opts = {
                     www_dir: options.www_dir,
                     cli_variables: options.cli_variables,
-                    is_top_level: false /* TODO: should this "is_top_level" param be false for dependents? */
+                    is_top_level: (tlps.indexOf(dangler) > -1 ? true : false)
                 };
                 return runUninstall(actions, platform, project_dir, dependent_path, plugins_dir, opts);
             })


### PR DESCRIPTION
CB-5016: Plugman was always assuming that a plugin found as a dependency was _installed_ as a dependency. This led to a problem where explicitly adding a dependent plugin manually would lead to a broken state after removing the "parent" plugin because the dependent plugins entry would still be in the plugins/{platform}.json file. The change just checks to see if the plugin to be deleted is listed as a dependency_plugin or an installed_plugin and sets "is_top_level" so that the entry is correctly removed from {platform}.json. Tested with npm test, no failures.
