### PR TITLE
[CB-5258] use exit library

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@
 // copyright (c) 2013 Andrew Lunny, Adobe Systems
 var path = require('path')
     , url = require('url')
+    , exit = require('exit')
     , package = require(path.join(__dirname, 'package'))
     , nopt = require('nopt')
     , plugins = require('./src/util/plugins')
@@ -57,7 +58,7 @@ process.on('uncaughtException', function(error) {
     } else {
         console.error(error.message);
     }
-    process.exit(1);
+    exit(1);
 });
 
 // Set up appropriate logging based on events

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "plist": "0.4.x",
     "bplist-parser": "0.0.x",
     "shelljs": "0.1.x",
+    "exit": "0.1.1",
     "osenv": "0.0.x",
     "ncallbacks":"1.1.0",
     "underscore":"1.4.4",


### PR DESCRIPTION
On Windows, if you have pending bits in pipes and you exit, they
generally do not get delivered.

To avoid this, you need to change process.exit() to something
which actually ensures that buffers are flushed before it exits,
this is handled by the 'exit' module/function.
