### PR TITLE
CB-5495, CB=5568 fix config.xml path for ios

### DIFF
--- a/src/util/config-changes.js
+++ b/src/util/config-changes.js
@@ -449,6 +449,14 @@ function isBinaryPlist(filename) {
     // binary plists start with a magic header, "bplist"
     return buf.substring(0, 6) === 'bplist';
 }
+function getIOSProjectname(project_dir){
+  var matches = glob.sync(path.join(project_dir, '*.xcodeproj'));
+  var iospath= project_dir;
+  if (matches.length) {
+      iospath = path.basename(matches[0],'.xcodeproj');
+  }
+  return iospath;
+}
 
 // Some config-file target attributes are not qualified with a full leading directory, or contain wildcards. resolve to a real path in this function
 function resolveConfigFilePath(project_dir, platform, file) {
@@ -462,6 +470,9 @@ function resolveConfigFilePath(project_dir, platform, file) {
         if (file == 'config.xml') {
             if (platform == 'ubuntu') {
                 filepath = path.join(project_dir, 'config.xml');
+            } else if (platform == 'ios') {
+                var iospath = getIOSProjectname(project_dir);
+                filepath = path.join(project_dir,iospath, 'config.xml');
             } else if (platform == 'android') {
                 filepath = path.join(project_dir, 'res', 'xml', 'config.xml');
             } else {


### PR DESCRIPTION
explicitly find the correct config.xml path for ios.
this still leaves other platforms (not ubuntu, android, ios) possibly broken 
