### PR TITLE
CB-5720 add resource-file to plugin.xml 

### DIFF
--- a/src/platforms/amazon-fireos.js
+++ b/src/platforms/amazon-fireos.js
@@ -58,6 +58,7 @@ module.exports = {
     },
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }

--- a/src/platforms/android.js
+++ b/src/platforms/android.js
@@ -60,13 +60,12 @@ module.exports = {
         install:function(el, plugin_dir, project_dir) {
             var src = el.attrib.src;
             var target = el.attrib.target;
-            var dest = path.join("res", target);
-            common.copyFile(plugin_dir, src, project_dir, dest);
+            require('../../plugman').emit('verbose', 'copying file ' + src + ' to ' + target);
+            common.copyFile(plugin_dir, src, project_dir, target);
         },
         uninstall:function(el, project_dir) {
             var target = el.attrib.target;
-            var dest = path.join("res", target);
-            common.removeFile(project_dir, dest);
+            common.removeFile(project_dir, target);
         }
     }
 };

--- a/src/platforms/blackberry10.js
+++ b/src/platforms/blackberry10.js
@@ -67,6 +67,7 @@ module.exports = {
     },
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }

--- a/src/platforms/firefoxos.js
+++ b/src/platforms/firefoxos.js
@@ -22,6 +22,7 @@ module.exports = {
     },
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }

--- a/src/platforms/windows8.js
+++ b/src/platforms/windows8.js
@@ -60,6 +60,7 @@ module.exports = {
     },
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }

--- a/src/platforms/wp7.js
+++ b/src/platforms/wp7.js
@@ -55,6 +55,7 @@ module.exports = {
     },
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }

--- a/src/platforms/wp8.js
+++ b/src/platforms/wp8.js
@@ -55,6 +55,7 @@ module.exports = {
     },  
     "resource-file":{
         install:function(el, plugin_dir, project_dir) {
+          require('../../plugman').emit('verbose', 'resource-file is not supported on this platform');
         },
         uninstall:function(el, project_dir) {
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-5720

Add support for <resource-file src="glass.xml" target="xml/glass.xml" /> to a plugin's plugin.xml

The above example would copy the file glass.xml from the plugin's directory to the platforms/android/res/xml/glass.xml

This is for the use case when a plugin in needs additional file e.g. in res/xml or other directories.
An example for Android would be an authenticator that is specified in AndroidManifest.xml
