### PR TITLE
CB-5885 Allow simultaneous install/uninstall of multiple plugins

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ var path = require('path')
 
 var known_opts = { 'platform' : [ 'ios', 'android', 'amazon-fireos', 'blackberry10', 'wp7', 'wp8' , 'windows8', 'firefoxos' ]
         , 'project' : path
-        , 'plugin' : [String, path, url]
+        , 'plugin' : [String, path, url, Array]
         , 'version' : Boolean
         , 'help' : Boolean
         , 'debug' : Boolean

--- a/plugman.js
+++ b/plugman.js
@@ -20,6 +20,7 @@
 // copyright (c) 2013 Andrew Lunny, Adobe Systems
 
 var emitter = require('./src/events');
+var Q = require('q');
 
 function addProperty(o, symbol, modulePath, doWrap) {
     var val = null;
@@ -102,13 +103,29 @@ plugman.commands =  {
             www_dir: cli_opts.www,
             searchpath: cli_opts.searchpath
         };
-        return plugman.install(cli_opts.platform, cli_opts.project, cli_opts.plugin, cli_opts.plugins_dir, opts);
+
+        var p = Q();
+        cli_opts.plugin.forEach(function (pluginSrc) {
+            p = p.then(function () {
+                return plugman.raw.install(cli_opts.platform, cli_opts.project, pluginSrc, cli_opts.plugins_dir, opts);
+            })
+        });
+        
+        return p;
     },
     'uninstall': function(cli_opts) {
         if(!cli_opts.platform || !cli_opts.project || !cli_opts.plugin) {
             return console.log(plugman.help());
         }
-        return plugman.uninstall(cli_opts.platform, cli_opts.project, cli_opts.plugin, cli_opts.plugins_dir, { www_dir: cli_opts.www });
+
+        var p = Q();
+        cli_opts.plugin.forEach(function (pluginSrc) {
+            p = p.then(function () {
+                return plugman.raw.uninstall(cli_opts.platform, cli_opts.project, pluginSrc, cli_opts.plugins_dir, { www_dir: cli_opts.www });
+            });
+        });
+
+        return p;
     },
     'adduser'  : function(cli_opts) {
         plugman.adduser(function(err) {

--- a/spec/platforms/ios.spec.js
+++ b/spec/platforms/ios.spec.js
@@ -68,6 +68,7 @@ shell.mkdir('-p', temp);
 shell.cp('-rf', ios_config_xml_project, temp);
 var proj_files = ios.parseProjectFile(temp);
 shell.rm('-rf', temp);
+ios.purgeProjectFileCache(temp);
 
 function copyArray(arr) {
     return Array.prototype.slice.call(arr, 0);
@@ -80,6 +81,7 @@ describe('ios project handler', function() {
     });
     afterEach(function() {
         shell.rm('-rf', temp);
+        ios.purgeProjectFileCache(temp);
     });
 
     describe('www_dir method', function() {
@@ -295,7 +297,7 @@ describe('ios project handler', function() {
             it('should rm the file from the right target location when element has no target-dir', function(){
                 var source = copyArray(valid_source).filter(function(s) { return s.attrib['target-dir'] == undefined});
                 shell.cp('-rf', ios_config_xml_project, temp);
-            
+
                 var spy = spyOn(shell, 'rm');
                 ios['source-file'].uninstall(source[0], temp, dummy_id, proj_files);
                 expect(spy).toHaveBeenCalledWith('-rf', path.join(temp, 'SampleApp', 'Plugins', dummy_id, 'DummyPluginCommand.m'));

--- a/spec/util/config-changes.spec.js
+++ b/spec/util/config-changes.spec.js
@@ -36,6 +36,7 @@ describe('config-changes module', function() {
     });
     afterEach(function() {
         shell.rm('-rf', temp);
+        ios_parser.purgeProjectFileCache(temp);
     });
 
     describe('queue methods', function() {
@@ -462,6 +463,7 @@ describe('config-changes module', function() {
                 // set up an uninstall
                 configChanges.add_uninstalled_plugin_to_prepare_queue(plugins_dir, 'DummyPlugin', 'ios');
 
+                ios_parser.purgeProjectFileCache(temp);
                 var spy = spyOn(plist, 'parseFileSync').andReturn({Plugins:{}});
                 configChanges.process(plugins_dir, temp, 'ios');
                 expect(spy).toHaveBeenCalledWith(path.join(temp, 'SampleApp', 'PhoneGap.plist').replace(/\\/g, '/'));
@@ -474,6 +476,7 @@ describe('config-changes module', function() {
                 // set up an uninstall
                 configChanges.add_uninstalled_plugin_to_prepare_queue(plugins_dir, 'DummyPlugin', 'ios');
 
+                ios_parser.purgeProjectFileCache(temp);
                 spyOn(plist, 'parseFileSync').andReturn({Plugins:{}});
                 var spy = spyOn(plugman, 'emit');
                 configChanges.process(plugins_dir, temp, 'ios');

--- a/src/platforms/ios.js
+++ b/src/platforms/ios.js
@@ -22,7 +22,8 @@ var path = require('path')
   , glob = require('glob')
   , xcode = require('xcode')
   , plist = require('plist-with-patches')
-  , shell = require('shelljs');
+  , shell = require('shelljs')
+  , cachedProjectFiles = {};
 
 module.exports = {
     www_dir:function(project_dir) {
@@ -139,6 +140,9 @@ module.exports = {
         }
     },
     parseProjectFile:function(project_dir) {
+        if (cachedProjectFiles[project_dir]) {
+            return cachedProjectFiles[project_dir];
+        }
         // grab and parse pbxproj
         // we don't want CordovaLib's xcode project
         var project_files = glob.sync(path.join(project_dir, '*.xcodeproj', 'project.pbxproj'));
@@ -170,7 +174,7 @@ module.exports = {
         var pluginsDir = path.resolve(xcode_dir, 'Plugins');
         var resourcesDir = path.resolve(xcode_dir, 'Resources');
 
-        return {
+        cachedProjectFiles[project_dir] = {
             plugins_dir:pluginsDir,
             resources_dir:resourcesDir,
             xcode:xcodeproj,
@@ -180,7 +184,13 @@ module.exports = {
                 fs.writeFileSync(pbxPath, xcodeproj.writeSync());
             }
         };
+
+        return cachedProjectFiles[project_dir];
+    },
+    purgeProjectFileCache:function(project_dir) {
+        delete cachedProjectFiles[project_dir];
     }
+
 };
 
 function getRelativeDir(file) {

--- a/src/util/config-changes.js
+++ b/src/util/config-changes.js
@@ -290,7 +290,7 @@ module.exports = {
         // save
         module.exports.save_platform_json(platform_config, plugins_dir, platform);
     },
-    add_plugin_changes:function(platform, project_dir, plugins_dir, plugin_id, plugin_vars, is_top_level, should_increment, cache) {
+    add_plugin_changes:function(platform, project_dir, plugins_dir, plugin_id, plugin_vars, is_top_level, should_increment) {
         var platform_config = module.exports.get_platform_json(plugins_dir, platform);
         var plugin_dir = path.join(plugins_dir, plugin_id);
 
@@ -301,10 +301,7 @@ module.exports = {
         // global munge looks at all plugins' changes to config files
         var global_munge = platform_config.config_munge;
 
-        var plistObj;
-        // Cache some slow stuff for reuse with multiple plugins.
-        cache = cache || {};
-        var pbxproj = cache.pbxproj;
+        var plistObj, pbxproj;
 
         if (platform == 'ios') {
             if (config_munge['plugins-plist']) {
@@ -318,10 +315,7 @@ module.exports = {
                 }
             }
             if (config_munge['framework']) {
-                if (!pbxproj) {
-                    // Note, parseProjectFile() is slow, ~250ms on MacBook Pro 2013.
-                    cache.pbxproj = pbxproj = ios_parser.parseProjectFile(project_dir);
-                }
+                pbxproj = ios_parser.parseProjectFile(project_dir);
             }
         }
 
@@ -435,9 +429,8 @@ module.exports = {
         });
 
         // Now handle installation
-        var cache = {};
         platform_config.prepare_queue.installed.forEach(function(u) {
-            module.exports.add_plugin_changes(platform, project_dir, plugins_dir, u.plugin, u.vars, u.topLevel, true, cache);
+            module.exports.add_plugin_changes(platform, project_dir, plugins_dir, u.plugin, u.vars, u.topLevel, true);
         });
 
         platform_config = module.exports.get_platform_json(plugins_dir, platform);


### PR DESCRIPTION
This PR allows plugman to install or uninstall a list of plugins with one invocation. This speeds up the installation of 20 plugins with about 20 to 50% and that of 5 plugins with up to 100%. The list is specified by repeating the --plugin <url, path, id> option as many times as needed.

<b>Update:</b> Added a simple cache in the <b>ios.parseProjectFile</b> function. This additionally speeds up the installation of ios plugins several times depending on the complexity of the project.

https://issues.apache.org/jira/browse/CB-5885
