### PR TITLE
CB-6344: Specify after which sibling to add config-changes in plugin.xml

### DIFF
--- a/spec/plugins/DummyPlugin/plugin.xml
+++ b/spec/plugins/DummyPlugin/plugin.xml
@@ -155,6 +155,28 @@
             <feature id="dummyPlugin" required="true" version="1.0.0.0"/>
         </config-file>
 
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App" after="Tokens">
+            <Extensions />
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Extensions" after="Extension">
+            <Extension ExtensionName="DummyExtension1" ConsumerID="{5B04B775-356B-4AA0-AAF8-6491FFEA5661}" TaskID="_default" ExtraFile="Extensions\\Extras.xml" />
+            <Extension ExtensionName="DummyExtension2" ConsumerID="{5B04B775-356B-4AA0-AAF8-6491FFEA5661}" TaskID="_default" ExtraFile="Extensions\\Extras.xml" />
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Extensions" after="FileTypeAssociation;Extension">
+            <FileTypeAssociation TaskID="_default" Name="DummyFileType1" NavUriFragment="fileToken=%s">
+                <SupportedFileTypes>
+                    <FileType ContentType="application/dummy1">.dummy1</FileType>
+                </SupportedFileTypes>
+            </FileTypeAssociation>
+            <FileTypeAssociation TaskID="_default" Name="DummyFileType2" NavUriFragment="fileToken=%s">
+                <SupportedFileTypes>
+                    <FileType ContentType="application/dummy2">.dummy2</FileType>
+                </SupportedFileTypes>
+            </FileTypeAssociation>
+        </config-file>
+
         <source-file src="src/wp8/DummyPlugin.cs"/>
         <js-module src="www/dummyplugin.js" name="Dummy">
             <clobbers target="dummy" />

--- a/spec/util/xml-helpers.spec.js
+++ b/spec/util/xml-helpers.spec.js
@@ -139,5 +139,32 @@ describe('xml-helpers', function(){
                 selector= "/bookstore/book[price>35]/title";
             expect(xml_helpers.graftXML(doc, children, selector)).toBe(false);
         });
+
+        it('appends children after the specified sibling', function () {
+            var doc = new et.ElementTree(et.XML('<widget><A/><B/><C/></widget>')),
+                children = [et.XML('<B id="new"/>'), et.XML('<B id="new2"/>')],
+                selector= "/widget",
+                after= "B;A";
+            expect(xml_helpers.graftXML(doc, children, selector, after)).toBe(true);
+            expect(et.tostring(doc.getroot())).toContain('<B /><B id="new" /><B id="new2" />');
+        });
+
+        it('appends children after the 2nd priority sibling if the 1st one is missing', function () {
+            var doc = new et.ElementTree(et.XML('<widget><A/><C/></widget>')),
+                children = [et.XML('<B id="new"/>'), et.XML('<B id="new2"/>')],
+                selector= "/widget",
+                after= "B;A";
+            expect(xml_helpers.graftXML(doc, children, selector, after)).toBe(true);
+            expect(et.tostring(doc.getroot())).toContain('<A /><B id="new" /><B id="new2" />');
+        });
+
+        it('inserts children at the beginning if specified sibling is missing', function () {
+            var doc = new et.ElementTree(et.XML('<widget><B/><C/></widget>')),
+                children = [et.XML('<A id="new"/>'), et.XML('<A id="new2"/>')],
+                selector= "/widget",
+                after= "A";
+            expect(xml_helpers.graftXML(doc, children, selector, after)).toBe(true);
+            expect(et.tostring(doc.getroot())).toContain('<widget><A id="new" /><A id="new2" />');
+        });
     });
 });


### PR DESCRIPTION
- refactor munges - now they are in a more extensible form (munge.files[file].parents[parent][index] { xml, count, after })
- add an after parameter to graftXML which contains a list of possible predecessor elements separated by semicolon
- fix unit tests and add new ones

https://github.com/apache/cordova-cli/pull/157 fixes the tests which failed the previous time these changes got merged.
