### PR TITLE
CB-6414 - fixes the issue where two config.xml munges exists, it will st...

### DIFF
--- a/src/util/config-changes.js
+++ b/src/util/config-changes.js
@@ -274,10 +274,6 @@ function reapply_global_munge () {
             );
             continue;
         }
-        if(file == 'config.xml') {
-            file = resolveConfigFilePath(self.project_dir, self.platform, file);
-            file = path.relative(self.project_dir, file);
-        }
 
         self.apply_file_munge(file, global_munge.files[file]);    
     }
@@ -390,7 +386,14 @@ function ConfigKeeper() {
 ConfigKeeper.prototype.get = ConfigKeeper_get;
 function ConfigKeeper_get(project_dir, platform, file) {
     var self = this;
+
+    //This fixes a bug with older plugins - when specifying config xml instead of res/xml/config.xml
+    //https://issues.apache.org/jira/browse/CB-6414
+    if(file == 'config.xml' && platform == 'android'){
+        file = 'res/xml/config.xml';
+    }
     var fake_path = path.join(project_dir, platform, file);
+
     if (self._cached[fake_path]) {
         return self._cached[fake_path];
     }


### PR DESCRIPTION
As seen in this issue:

https://issues.apache.org/jira/browse/CB-6414

Referencing this comment by @kamrik here: https://github.com/apache/cordova-plugman/pull/72

I've corrected the code for both iOS and Android by correcting the code in config_keeper.
