### PR TITLE
CB-9332 Removes unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
   "dependencies": {
     "cordova-lib": "5.1.1",
     "nopt": "1.0.9",
-    "underscore":"1.7.0",
-    "q": "1.0.1",
-    "npm": "1.3.4",
-    "rc": "0.5.2"
+    "q": "1.0.1"
   },
   "devDependencies": {
     "jshint": "2.5.8",


### PR DESCRIPTION
This PR removes excess dependency on 'npm'. See https://issues.apache.org/jira/browse/CB-9332