### PR TITLE
CB-12018 : updated tests to work with jasmine instead of jasmine-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,72 +1,73 @@
 {
-    "author": "Andrew Lunny <alunny@gmail.com>",
-    "name": "plugman",
-    "description": "install/uninstall Cordova plugins",
-    "version": "1.4.1-dev",
-    "repository": {
-        "type": "git",
-        "url": "git://git-wip-us.apache.org/repos/asf/cordova-plugman.git"
+  "author": "Andrew Lunny <alunny@gmail.com>",
+  "name": "plugman",
+  "description": "install/uninstall Cordova plugins",
+  "version": "1.4.1-dev",
+  "repository": {
+    "type": "git",
+    "url": "git://git-wip-us.apache.org/repos/asf/cordova-plugman.git"
+  },
+  "bugs": {
+    "url": "https://issues.apache.org/jira/browse/CB",
+    "email": "dev@cordova.apache.org"
+  },
+  "main": "plugman.js",
+  "engines": {
+    "node": ">=0.9.9"
+  },
+  "engineStrict": true,
+  "dependencies": {
+    "cordova-lib": "6.4.0",
+    "jasmine": "^2.5.3",
+    "nopt": "1.0.9",
+    "q": "1.0.1"
+  },
+  "devDependencies": {
+    "jshint": "2.5.8",
+    "jasmine": "2.5.3"
+  },
+  "bin": {
+    "plugman": "./main.js"
+  },
+  "scripts": {
+    "test": "npm run jasmine && jshint",
+    "jshint": "jshint src",
+    "jasmine": "jasmine --captureExceptions --color"
+  },
+  "license": "Apache-2.0",
+  "contributors": [
+    {
+      "name": "Anis Kadri"
     },
-    "bugs": {
-        "url": "https://issues.apache.org/jira/browse/CB",
-        "email": "dev@cordova.apache.org"
+    {
+      "name": "Tim Kim"
     },
-    "main": "plugman.js",
-    "engines": {
-        "node": ">=0.9.9"
+    {
+      "name": "Braden Shepherdson"
     },
-    "engineStrict": true,
-    "dependencies": {
-        "cordova-lib": "6.4.0",
-        "nopt": "1.0.9",
-        "q": "1.0.1"
+    {
+      "name": "Ryan Willoughby"
     },
-    "devDependencies": {
-        "jshint": "2.5.8",
-        "jasmine-node": "1.14.5"
+    {
+      "name": "Brett Rudd"
     },
-    "bin": {
-        "plugman": "./main.js"
+    {
+      "name": "Mike Reinstein"
     },
-    "scripts": {
-        "test": "npm run jasmine && npm run jshint",
-        "jshint": "node node_modules/jshint/bin/jshint src",
-        "jasmine": "jasmine-node --captureExceptions --color spec"
+    {
+      "name": "Shazron Abdullah"
     },
-    "license": "Apache-2.0",
-    "contributors": [
-        {
-            "name": "Anis Kadri"
-        },
-        {
-            "name": "Tim Kim"
-        },
-        {
-            "name": "Braden Shepherdson"
-        },
-        {
-            "name": "Ryan Willoughby"
-        },
-        {
-            "name": "Brett Rudd"
-        },
-        {
-            "name": "Mike Reinstein"
-        },
-        {
-            "name": "Shazron Abdullah"
-        },
-        {
-            "name": "Steve Gill"
-        },
-        {
-            "name": "Fil Maj"
-        },
-        {
-            "name": "Michael Brooks"
-        },
-        {
-            "name": "Jesse MacFadyen"
-        }
-    ]
+    {
+      "name": "Steve Gill"
+    },
+    {
+      "name": "Fil Maj"
+    },
+    {
+      "name": "Michael Brooks"
+    },
+    {
+      "name": "Jesse MacFadyen"
+    }
+  ]
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,8 @@
+{
+    "spec_dir": "spec",
+    "spec_files": [
+        "**/*[sS]pec.js"
+    ],
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
Updated package.json and added jasmine.json so that current tests and tests going forward will work with jasmine instead of jasmine-node.

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
