### PR TITLE
Cordova Plugman Release Preparation (Cordova 9) 

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,7 +36,7 @@ const known_opts = {
     ],
     project: path,
     plugin: [String, path, url, Array],
-    version: Boolean,
+    version: String,
     help: Boolean,
     debug: Boolean,
     silent: Boolean,
@@ -45,7 +45,11 @@ const known_opts = {
     variable: Array,
     www: path,
     searchpath: [path, Array],
-    save: Boolean
+    save: Boolean,
+    name: String,
+    platform_id: String,
+    platform_version: String,
+    plugins_dir: String
 };
 const shortHands = { var: ['--variable'], v: ['--version'], h: ['--help'] };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-node": "^5.0.0",
+    "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "jasmine": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nopt": "^4.0.1"
   },
   "devDependencies": {
-    "eslint": "^4.2.0",
+    "eslint": "^5.15.3",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "eslint": "^5.15.3",
-    "eslint-config-semistandard": "^11.0.0",
+    "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "cordova-lib": "8.0.0",
+    "cordova-lib": "^9.0.0",
     "nopt": "1.0.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^5.15.3",
     "eslint-config-semistandard": "^13.0.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^5.0.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "^3.3.1"
+    "jasmine": "^3.3.1",
+    "rewire": "^4.0.1"
   },
   "bin": {
     "plugman": "./main.js"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "engineStrict": true,
   "dependencies": {
     "cordova-lib": "^9.0.0",
-    "nopt": "1.0.9"
+    "nopt": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "eslint": "^5.15.3",
     "eslint-config-semistandard": "^13.0.0",
-    "eslint-config-standard": "^10.2.1",
+    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^5.0.0",
     "eslint-plugin-promise": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "^3.1.0"
+    "jasmine": "^3.3.1"
   },
   "bin": {
     "plugman": "./main.js"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^3.0.1",
     "jasmine": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.1.0"
   },
   "bin": {

--- a/spec/nopt.interface.spec.js
+++ b/spec/nopt.interface.spec.js
@@ -16,12 +16,16 @@
     specific language governing permissions and limitations
     under the License.
 */
-var nopt = require('nopt');
+const nopt = require('nopt');
+const rewire = require('rewire');
+const main = rewire('../main');
 
-describe('nopt interface check', function () {
-    // https://issues.apache.org/jira/browse/CB-7915
-    it('parameters without assignment operator should be assigned', function () {
-        var cli_opts = nopt(null, null, ['plugman', 'create', '--name', 'MyName', '--platform_id', 'MyId', '--platform_version', '1.0.0']);
+describe('nopt interface check', () => {
+    it('parameters without assignment operator should be assigned', () => {
+        const knownOptions = main.__get__('known_opts');
+        const shortHands = main.__get__('shortHands');
+        const cli_opts = nopt(knownOptions, shortHands, ['plugman', 'create', '--name', 'MyName', '--platform_id', 'MyId', '--platform_version', '1.0.0']);
+
         expect(cli_opts.name).toEqual('MyName');
         expect(cli_opts.platform_id).toEqual('MyId');
         expect(cli_opts.platform_version).toEqual('1.0.0');


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Cordova 9 Release

### Description
This PR contains final preparations for the Cordova 9 release goals. 

See [Cordova 9 Release Plan](https://github.com/apache/cordova/issues/10).

- Added missing known options that causes the latest `nopt` to display Boolean values vs String values.
- Changed `version` from boolean to string.
- Updated test to use actual `knownOptions` and `shortHands`

- **Bumped Dependencies**
  - `cordova-lib@^9.0.0`
  - `nopt@^4.0.1`
- **Bumped ESLint dependencies with correction**
  - `eslint@^5.15.3`
  - `eslint-config-semistandard@^13.0.0`
  - `eslint-config-standard@^12.0.0`
  - `eslint-plugin-import@^2.16.0`
  - `eslint-plugin-node@^8.0.1`
  - `eslint-plugin-promise@^4.0.1`
  - `eslint-plugin-standard@^4.0.0`
- **Updated Dev Dependencies**
  - `jasmine@^3.3.1`
  - `rewire@^4.0.1`

### Testing
- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
