### PR TITLE
chore: remove deprecated `engineStrict`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "engines": {
     "node": ">=6"
   },
-  "engineStrict": true,
   "dependencies": {
     "cordova-lib": "^9.0.0",
     "loud-rejection": "^1.6.0",


### PR DESCRIPTION
part of https://github.com/apache/cordova/issues/86

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
