### PR TITLE
chore: bump node requirement (>=10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "plugman.js",
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "dependencies": {
     "cordova-lib": "^9.0.0",


### PR DESCRIPTION
### Motivation and Context

* Follow inline with Node Support
* Prepare for next major
* https://github.com/apache/cordova/issues/79

### Description

* Bump `engines.node` to `>=10` in `package.json`

### Testing

- `npm t`
- CI services continue to pass

### Checklist

- [x] I've run the tests to see all new and existing tests pass
