### PR TITLE
chore(asf): add github meta data

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,6 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
+github:
+  description: Apache Cordova Plugman
+  homepage: https://cordova.apache.org/
+
+  labels:
+    - cordova
+    - cplusplus
+    - csharp
+    - hacktoberfest
+    - java
+    - javascript
+    - library
+    - mobile
+    - nodejs
+    - objective-c
+
 notifications:
   commits:              commits@cordova.apache.org
   issues:               issues@cordova.apache.org


### PR DESCRIPTION
### Motivation, Context & Description

Add GitHub meta data to asf config, e.g. `title`, `website`, `labels`.
Add the `hacktoberfest` tag to this repo.

### Testing

N/A