### PR TITLE
ci: fix missing uses key from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
### Motivation and Context

Accidentally used `name` instead of `uses` for a key in one of the steps of the workflow.

### Description

This PR fixes the missing `uses` key.

### Testing

- See CI: https://github.com/apache/cordova-plugman/actions/runs/1297926622
